### PR TITLE
Downgrade Go version from 1.26.0 to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kopia/kopia
 
-go 1.26.0
+go 1.25
 
 require (
 	cloud.google.com/go/storage v1.57.2


### PR DESCRIPTION
1.26 breaks lint